### PR TITLE
Fix Parser Bug causing 2x Dupe Data & Optimize Parser

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,78 @@
+You are an expert in data analysis, visualization, and Jupyter Notebook development, 
+with a focus on Python libraries such as pandas, matplotlib, seaborn, and numpy.
+
+Coding Influences:
+We aspire to write code of the quality and style exemplified by:
+- fastai (https://github.com/fastai/fastai). 
+- jeremy howard (founder of kaggle and fastai) https://github.com/jph00 https://www.kaggle.com/jhoward/code
+
+
+Key Principles:
+- Write concise, technical responses with accurate Python examples.
+- Prioritize readability and reproducibility in data analysis workflows.
+- Use functional programming where appropriate; avoid unnecessary classes.
+- Prefer vectorized operations over explicit loops for better performance.
+- Use descriptive variable names that reflect the data they contain.
+- Follow PEP 8 style guidelines for Python code.
+
+Data Analysis and Manipulation:
+- Use pandas for data manipulation and analysis.
+- Prefer method chaining for data transformations when possible.
+- Use loc and iloc for explicit data selection.
+- Utilize groupby operations for efficient data aggregation.
+
+Visualization:
+- Use matplotlib for low-level plotting control and customization.
+- Use seaborn for statistical visualizations and aesthetically pleasing defaults.
+- Create informative and visually appealing plots with proper labels, titles, and legends.
+- Use appropriate color schemes
+
+Jupyter Notebook Best Practices:
+- Structure notebooks with clear sections using markdown cells.
+- Use meaningful cell execution order to ensure reproducibility.
+- Include explanatory text in markdown cells to document analysis steps.
+- Keep code cells focused and modular for easier understanding and debugging.
+- Use magic commands like %matplotlib inline for inline plotting.
+
+Error Handling and Data Validation:
+- Implement data quality checks at the beginning of analysis.
+- Handle missing data appropriately (imputation, removal, or flagging).
+- Use try-except blocks for error-prone operations, especially when reading external data.
+- Validate data types and ranges to ensure data integrity.
+
+Performance Optimization:
+- Use vectorized operations in pandas and numpy for improved performance.
+- Utilize efficient data structures (e.g., categorical data types for low-cardinality string columns).
+- Consider using dask for larger-than-memory datasets.
+- Profile code to identify and optimize bottlenecks.
+
+Dependencies:
+- fastai
+- pandas
+- numpy
+- matplotlib
+- seaborn
+- jupyter
+- scikit-learn (for machine learning tasks that fastai does not cover)
+
+Key Conventions:
+1. Begin analysis with data exploration and summary statistics.
+2. Create reusable plotting functions for consistent visualizations.
+3. Document data sources, assumptions, and methodologies clearly.
+4. Use version control (e.g., git) for tracking changes in notebooks and scripts.
+
+Refer to the official documentation of pandas, matplotlib, and Jupyter for best practices and up-to-date APIs.
+
+
+You are an AI assistant specialized in Python development. Your approach emphasizes:
+
+1. Clear project structure with separate directories for source code, tests, docs, and config.
+2. Modular design with distinct files for models, services, controllers, and utilities.
+3. Configuration management using environment variables.
+4. Robust error handling and logging, including context capture.
+5. Comprehensive testing with pytest.
+6. Detailed documentation using docstrings and README files.
+- Detailed comments for complex logic
+- Rich error context for debugging
+
+You provide code snippets and explanations tailored to these principles, optimizing for clarity and AI-assisted development.

--- a/data_logger.py
+++ b/data_logger.py
@@ -1,0 +1,89 @@
+import csv
+import time
+from datetime import datetime
+import os
+import numpy as np
+from zmq import device
+
+import umyo_class
+
+class DataLogger:
+    def __init__(self, base_path="logs"):
+        self.base_path = base_path
+        self.current_file = None
+        self.csv_writer = None
+        self.session_start_time = None
+        self.rows_since_flush = 0
+        self._ensure_log_directory()
+        
+    def _ensure_log_directory(self):
+        """Create logs directory if it doesn't exist"""
+        if not os.path.exists(self.base_path):
+            os.makedirs(self.base_path)
+    
+    def start_new_session(self):
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = os.path.join(self.base_path, f"umyo_session_{timestamp}.csv")
+        self.current_file = open(filename, 'w', newline='')
+        self.csv_writer = csv.writer(self.current_file)
+        self.session_start_time = time.time()
+        
+        # Write header - one column per value
+        self.csv_writer.writerow([
+            'timestamp',
+            'device_id',
+            # EMG data columns (8 values)
+            *[f'emg_{i}' for i in range(8)],
+            # Spectrogram columns (4 bands)
+            *[f'spg_band_{i}' for i in range(4)],
+            'ax', 'ay', 'az',
+            'quat_w', 'quat_x', 'quat_y', 'quat_z',
+            'mag_angle',
+            'rssi',
+            'battery'
+        ])
+        
+    def log_device_data(self, device, timestamp):
+        """Log device data with provided timestamp"""
+        if self.csv_writer is None:
+            return
+        
+        # Verify we have a valid device object
+        if not isinstance(device, umyo_class.uMyo):
+            print("\nWarning: Invalid device object")
+            return
+        
+        try:
+            # All attributes should exist, so we can access directly
+            row = [
+                f"{timestamp:.6f}",  # Explicitly format with 6 decimal places
+                device.unit_id,
+                *device.data_array[:8],
+                *device.device_spectr[:4],
+                device.ax,
+                device.ay,
+                device.az,
+                *device.Qsg[:4],
+                device.mag_angle,
+                device.rssi,
+                device.batt
+            ]
+            
+            self.csv_writer.writerow(row)
+            
+            # Flush every N rows
+            if self.rows_since_flush >= 100:
+                self.current_file.flush()
+                self.rows_since_flush = 0
+            else:
+                self.rows_since_flush += 1
+                
+        except Exception as e:
+            print(f"\nError logging data for device {device.unit_id}: {e}")
+
+    def close(self):
+        """Close the current logging session"""
+        if self.current_file is not None:
+            self.current_file.close()
+            self.current_file = None
+            self.csv_writer = None    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pyserial>=3.5
+pygame>=2.5.0
+numpy>=1.24.0
+matplotlib>=3.7.0

--- a/simple_data_logger.py
+++ b/simple_data_logger.py
@@ -1,0 +1,108 @@
+import umyo_parser
+from data_logger import DataLogger
+from serial.tools import list_ports
+import serial
+import time
+import sys
+from datetime import datetime
+from collections import deque
+from statistics import mean
+
+
+def print_status(message, end='\r'):
+    """Print status message with carriage return to update in place"""
+    sys.stdout.write(f"\r{message}{' ' * 20}")
+    sys.stdout.flush()
+    if end == '\n':
+        sys.stdout.write('\n')
+
+# Initialize data logger
+logger = DataLogger()
+logger.start_new_session()
+
+# List and connect to port
+port = list(list_ports.comports())
+print("Available ports:")
+for i, p in enumerate(port):
+    print(f"{i}: {p.device}")
+    device = p.device
+print("===")
+
+# Setup serial connection
+ser = serial.Serial(
+    port=device,
+    baudrate=921600,
+    parity=serial.PARITY_NONE,
+    stopbits=1,
+    bytesize=8,
+    timeout=0
+)
+
+print(f"\nConnected to: {ser.portstr}")
+print("Waiting for device input... (Ctrl+C to exit)")
+
+try:
+    last_status_time = time.time()
+    last_data_time = time.time()
+    packet_count = 0
+    show_waiting = True
+    data_started = False
+    
+    while True:
+        current_time = time.time()
+        cnt = ser.in_waiting
+        
+        if cnt > 0:
+                
+            data = ser.read(cnt)
+
+            if not data_started:
+                data_started = True
+                stats_start_time = time.time()
+                print_status("Data collection started!", end='\n')
+            
+            parse_unproc_cnt = umyo_parser.umyo_parse_preprocessor(data)
+            devices = umyo_parser.umyo_get_list()
+            
+            # Log data for each device
+            for device in devices:
+                 if device is not None:  # Make sure we have a valid device
+                    receive_time = time.time() #- logger.session_start_time
+                    logger.log_device_data(device, receive_time)
+            
+            packet_count += 1
+            last_data_time = current_time   
+            
+            # Update receiving status every 2 seconds
+            if current_time - last_status_time >= 2.0:
+                duration = current_time - stats_start_time
+                print_status(f"Receiving data... (Packets: {packet_count//1000}k)")
+                last_status_time = current_time
+                stats_start_time = current_time
+                
+        elif not data_started:
+            # Blink waiting message every second
+            if current_time - last_status_time >= 1.0:
+                if show_waiting:
+                    print_status("Waiting for device input...")
+                else:
+                    print_status("                         ")  # Clear the line
+                show_waiting = not show_waiting
+                last_status_time = current_time
+
+except KeyboardInterrupt:
+    print_status("\nClosing gracefully...", end='\n')
+    
+except Exception as e:
+    print(f"\nError occurred: {e}")
+    
+finally:
+    try:
+        logger.close()
+    except:
+        pass
+    try:
+        ser.close()
+    except:
+        pass
+    print(f"Session ended: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")

--- a/simple_data_logger2.py
+++ b/simple_data_logger2.py
@@ -1,0 +1,154 @@
+import umyo_parser
+from data_logger import DataLogger
+from serial.tools import list_ports
+import serial
+import time
+import sys
+from datetime import datetime
+from datetime import datetime
+from collections import deque
+from statistics import mean
+
+
+def print_status(message, end='\r'):
+    """Print status message with carriage return to update in place"""
+    sys.stdout.write(f"\r{message}{' ' * 20}")
+    sys.stdout.flush()
+    if end == '\n':
+        sys.stdout.write('\n')
+
+def log_timing_stats(read_times, interval_times, packet_count, duration):
+    """Log detailed timing statistics"""
+    if not read_times:
+        return
+        
+    avg_read = mean(read_times)
+    avg_interval = mean(interval_times)
+    max_interval = max(interval_times)
+    packets_per_sec = packet_count / duration if duration > 0 else 0
+    
+    print_status(
+        f"\nTiming stats:"
+        f"\n  Avg read time: {avg_read*1000:.3f}ms"
+        f"\n  Avg interval: {avg_interval*1000:.3f}ms"
+        f"\n  Max interval: {max_interval*1000:.3f}ms"
+        f"\n  Packets/sec: {packets_per_sec:.1f}"
+        f"\n", 
+        end='\n'
+    )
+
+# Initialize data logger
+logger = DataLogger()
+logger.start_new_session()
+
+# List and connect to port
+port = list(list_ports.comports())
+print("Available ports:")
+for i, p in enumerate(port):
+    print(f"{i}: {p.device}")
+    device = p.device
+print("===")
+
+# Setup serial connection
+ser = serial.Serial(
+    port=device,
+    baudrate=921600,
+    parity=serial.PARITY_NONE,
+    stopbits=1,
+    bytesize=8,
+    timeout=0
+)
+
+#ser.set_buffer_size(rx_size=131072)  # 128KB receive buffer
+
+#ser.setRTS(False)
+#ser.setDTR(False)
+
+print(f"\nConnected to: {ser.portstr}")
+print("Waiting for device input... (Ctrl+C to exit)")
+
+try:
+    # Timing tracking
+    read_times = deque(maxlen=100)  # Track last 100 read times
+    interval_times = deque(maxlen=100)  # Track last 100 intervals
+    last_read_time = time.time()
+    stats_start_time = time.time()
+    stats_packet_count = 0
+
+    last_status_time = time.time()
+    last_data_time = time.time()
+    packet_count = 0
+    show_waiting = True
+    data_started = False
+    
+    while True:
+        current_time = time.time()
+        cnt = ser.in_waiting
+        
+        if cnt > 0:
+                
+             # Timing measurement
+            read_start = time.time()
+            data = ser.read(cnt)
+            read_end = time.time()
+
+            # Track timing
+            read_duration = read_end - read_start
+            interval = read_start - last_read_time
+            read_times.append(read_duration)
+            interval_times.append(interval)
+            last_read_time = read_start
+
+            if not data_started:
+                data_started = True
+                stats_start_time = time.time()
+                print_status("Data collection started!", end='\n')
+            
+            parse_unproc_cnt = umyo_parser.umyo_parse_preprocessor(data)
+            devices = umyo_parser.umyo_get_list()
+            
+            # Log data for each device
+            for device in devices:
+                 if device is not None:  # Make sure we have a valid device
+                    receive_time = time.time() #- logger.session_start_time
+                    logger.log_device_data(device, receive_time)
+            
+            packet_count += 1
+            stats_packet_count += 1
+            last_data_time = current_time
+            
+            # Update receiving status every 2 seconds
+            if current_time - last_status_time >= 2.0:
+                duration = current_time - stats_start_time
+                log_timing_stats(read_times, interval_times, stats_packet_count, duration)
+                print_status(f"Receiving data... (Packets: {packet_count//1000}k)")
+                last_status_time = current_time
+                stats_packet_count = 0
+                stats_start_time = current_time
+                
+        elif not data_started:
+            # Blink waiting message every second
+            if current_time - last_status_time >= 1.0:
+                if show_waiting:
+                    print_status("Waiting for device input...")
+                else:
+                    print_status("                         ")  # Clear the line
+                show_waiting = not show_waiting
+                last_status_time = current_time
+
+except KeyboardInterrupt:
+    print_status("\nClosing gracefully...", end='\n')
+    
+except Exception as e:
+    print(f"\nError occurred: {e}")
+    
+finally:
+    try:
+        logger.close()
+    except:
+        pass
+    try:
+        ser.close()
+    except:
+        pass
+    print(f"Session ended: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")

--- a/umyo_parser.py
+++ b/umyo_parser.py
@@ -1,172 +1,212 @@
 #parser
 
-import umyo_class
-import quat_math
-#from quat_math import sV
+from dataclasses import dataclass
+from typing import Dict
+from time import time
+from queue import Queue
+from loguru import logger
+from umyo_class import uMyo
 from quat_math import *
 import math
 
-parse_buf = bytearray(0)
+@dataclass
+class DeviceData:
+    """Represents a single packet of device data"""
+    device_id: int
+    timestamp: float
+    data: Dict[str, float]  # More specific: dictionary with string keys and float values
+    
+    @classmethod
+    def from_umyo(cls, device):
+        """Create DeviceData from a uMyo device"""
+        return cls(
+            device_id=device.unit_id,
+            timestamp=time(),
+            data={
+                'Qsg': device.Qsg.copy(),
+                'yaw': device.yaw,
+                'pitch': device.pitch,
+                'roll': device.roll,
+                'ax': device.ax,
+                'ay': device.ay,
+                'az': device.az,
+                'mag_angle': device.mag_angle,
+                'data_array': device.data_array.copy(),
+                'device_spectr': device.device_spectr.copy(),
+                'rssi': device.rssi,
+                'batt': device.batt,
+                'data_id': device.data_id
+            }
+        )
 
-umyo_list = []
-unseen_cnt = []
+class UMyoParser:
+    def __init__(self):
+        self.data_queue = Queue()
+        self.parse_buf = bytearray(0)
+        self.umyo_list = []
+        self.unseen_cnt = []
 
-def id2idx(uid):
-    cnt = len(umyo_list)
-    u = 0
-    while(u < cnt):
-        if(unseen_cnt[u] > 1000 and umyo_list[u].unit_id != uid):
-            del umyo_list[u]
-            del unseen_cnt[u]
-            cnt -= 1
-        else: u += 1
-    for u in range(cnt):
-        unseen_cnt[u] += 1
-        if(umyo_list[u].unit_id == uid): 
-            unseen_cnt[u] = 0
-            return u
+    def id2idx(self, uid):
+        cnt = len(self.umyo_list)
+        u = 0
+        while(u < cnt):
+            if(self.unseen_cnt[u] > 1000 and self.umyo_list[u].unit_id != uid):
+                del self.umyo_list[u]
+                del self.unseen_cnt[u]
+                cnt -= 1
+            else: u += 1
+        for u in range(cnt):
+            self.unseen_cnt[u] += 1
+            if(self.umyo_list[u].unit_id == uid): 
+                self.unseen_cnt[u] = 0
+                return u
         
-    umyo_list.append(umyo_class.uMyo(uid))
-    unseen_cnt.append(0)
-    return cnt
+        self.umyo_list.append(uMyo(uid))
+        self.unseen_cnt.append(0)
+        return cnt
 
-def umyo_parse(pos):
-    pp = pos
-    rssi = parse_buf[pp-1]; #pp is guaranteed to be >0 by design
-    packet_id = parse_buf[pp]; pp+=1
-    packet_len = parse_buf[pp]; pp+=1
-    unit_id = parse_buf[pp]; pp+=1; unit_id <<= 8
-    unit_id += parse_buf[pp]; pp+=1; unit_id <<= 8
-    unit_id += parse_buf[pp]; pp+=1; unit_id <<= 8
-    unit_id += parse_buf[pp]; pp+=1
-    idx = id2idx(unit_id)
-    packet_type = parse_buf[pp]; pp+=1
-    if(packet_type > 80 and packet_type < 120):
-        umyo_list[idx].data_count = packet_type - 80;
-        umyo_list[idx].packet_type = 80;
-    else:
-        return
+    def umyo_parse(self, pos):
+        pp = pos
+        rssi = self.parse_buf[pp-1]; #pp is guaranteed to be >0 by design
+        packet_id = self.parse_buf[pp]; pp+=1
+        packet_len = self.parse_buf[pp]; pp+=1
+        unit_id = self.parse_buf[pp]; pp+=1; unit_id <<= 8
+        unit_id += self.parse_buf[pp]; pp+=1; unit_id <<= 8
+        unit_id += self.parse_buf[pp]; pp+=1; unit_id <<= 8
+        unit_id += self.parse_buf[pp]; pp+=1
+        idx = self.id2idx(unit_id)
+        packet_type = self.parse_buf[pp]; pp+=1
+        if(packet_type > 80 and packet_type < 120):
+            self.umyo_list[idx].data_count = packet_type - 80;
+            self.umyo_list[idx].packet_type = 80;
+        else:
+            logger.warning(f"Invalid packet type {packet_type} for device {unit_id}")
+            return
 
-    umyo_list[idx].rssi = rssi
-    param_id = parse_buf[pp]; pp+=1
+        self.umyo_list[idx].rssi = rssi
+        param_id = self.parse_buf[pp]; pp+=1
 
-    pb1 = parse_buf[pp]; pp+=1
-    pb2 = parse_buf[pp]; pp+=1
-    pb3 = parse_buf[pp]; pp+=1
-    if(param_id == 0):
-        umyo_list[idx].batt = 2000 + pb1*10;
-        umyo_list[idx].version = pb2
-    data_id = parse_buf[pp]; pp+=1
+        pb1 = self.parse_buf[pp]; pp+=1
+        pb2 = self.parse_buf[pp]; pp+=1
+        pb3 = self.parse_buf[pp]; pp+=1
+        if(param_id == 0):
+            self.umyo_list[idx].batt = 2000 + pb1*10;
+            self.umyo_list[idx].version = pb2
+        data_id = self.parse_buf[pp]; pp+=1
 
-    d_id = data_id - umyo_list[idx].prev_data_id
-    umyo_list[idx].prev_data_id = data_id
-    if(d_id < 0): d_id += 256
-    umyo_list[idx].data_id += d_id
-    for x in range(umyo_list[idx].data_count):
-        hb = parse_buf[pp]; pp+=1
-        lb = parse_buf[pp]; pp+=1
-        val = hb*256 + lb
-        if(hb > 127):
-            val = -65536 + val
-        umyo_list[idx].data_array[x] = val
+        d_id = data_id - self.umyo_list[idx].prev_data_id
+        self.umyo_list[idx].prev_data_id = data_id
+        if(d_id < 0): d_id += 256
+        self.umyo_list[idx].data_id += d_id
+        for x in range(self.umyo_list[idx].data_count):
+            hb = self.parse_buf[pp]; pp+=1
+            lb = self.parse_buf[pp]; pp+=1
+            val = hb*256 + lb
+            if(hb > 127):
+                val = -65536 + val
+            self.umyo_list[idx].data_array[x] = val
 
-    for x in range(4):
-        hb = parse_buf[pp]; pp+=1
-        lb = parse_buf[pp]; pp+=1
-        val = hb*256 + lb
+        for x in range(4):
+            hb = self.parse_buf[pp]; pp+=1
+            lb = self.parse_buf[pp]; pp+=1
+            val = hb*256 + lb
 #        if(hb > 127):
 #            val = -65536 + val
-        umyo_list[idx].device_spectr[x] = val
+            self.umyo_list[idx].device_spectr[x] = val
 
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    qww = val
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    qwx = val
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    qwy = val
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    qwz = val
-
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    ax = val
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    ay = val
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    az = val
-    
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    yaw = val
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    pitch = val
-    hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
-    if(val > 32767): val = -(65536-val)
-    roll = val
-
-    mx = 0;
-    my = 0;
-    mz = 0;
-    if(pos + packet_len > pp + 5): #also has magn data
-        hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
         if(val > 32767): val = -(65536-val)
-        mx = val
-        hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        qww = val
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
         if(val > 32767): val = -(65536-val)
-        my = val
-        hb = parse_buf[pp]; pp+=1; lb = parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        qwx = val
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
         if(val > 32767): val = -(65536-val)
-        mz = val
+        qwy = val
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        if(val > 32767): val = -(65536-val)
+        qwz = val
+
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        if(val > 32767): val = -(65536-val)
+        ax = val
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        if(val > 32767): val = -(65536-val)
+        ay = val
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        if(val > 32767): val = -(65536-val)
+        az = val
+        
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        if(val > 32767): val = -(65536-val)
+        yaw = val
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        if(val > 32767): val = -(65536-val)
+        pitch = val
+        hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+        if(val > 32767): val = -(65536-val)
+        roll = val
+
+        mx = 0;
+        my = 0;
+        mz = 0;
+        if(pos + packet_len > pp + 5): #also has magn data
+            hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+            if(val > 32767): val = -(65536-val)
+            mx = val
+            hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+            if(val > 32767): val = -(65536-val)
+            my = val
+            hb = self.parse_buf[pp]; pp+=1; lb = self.parse_buf[pp]; pp+=1; val = hb*256 + lb    
+            if(val > 32767): val = -(65536-val)
+            mz = val
 
 
-    nyr = sV(0, 1, 0)
-    Qsg = sQ(qww, qwx, qwy, qwz)    
-    nyr = quat_math.rotate_v(Qsg, nyr);
-    yaw_q = math.atan2(nyr.y, nyr.x);
-    
-    M = sV(mx, my, mz)
-    M = v_renorm(M)
-    A = sV(ax, ay, -az)
-    A = v_renorm(A)
+        nyr = sV(0, 1, 0)
+        Qsg = sQ(qww, qwx, qwy, qwz)    
+        nyr = rotate_v(Qsg, nyr);
+        yaw_q = math.atan2(nyr.y, nyr.x);
+        
+        M = sV(mx, my, mz)
+        M = v_renorm(M)
+        A = sV(ax, ay, -az)
+        A = v_renorm(A)
 
-    m_vert = v_dot(A, M)
-    M_hor = sV(M.x - m_vert*A.x, M.y - m_vert*A.y, M.z - m_vert*A.z)
-    M_hor = v_renorm(M_hor)
-    H = sV(0, 1, 0);
-    h_vert = v_dot(A, H)
-    H_hor = sV(H.x - h_vert*A.x, H.y - h_vert*A.y, H.z - h_vert*A.z)
-    H_hor = v_renorm(H_hor)
-    HM = v_mult(H_hor, M_hor)
-    asign = -1
-    if(v_dot(HM, A) < 0): asign = 1
-    mag_angle = asign*math.acos(v_dot(H_hor, M_hor))
+        m_vert = v_dot(A, M)
+        M_hor = sV(M.x - m_vert*A.x, M.y - m_vert*A.y, M.z - m_vert*A.z)
+        M_hor = v_renorm(M_hor)
+        H = sV(0, 1, 0);
+        h_vert = v_dot(A, H)
+        H_hor = sV(H.x - h_vert*A.x, H.y - h_vert*A.y, H.z - h_vert*A.z)
+        H_hor = v_renorm(H_hor)
+        HM = v_mult(H_hor, M_hor)
+        asign = -1
+        if(v_dot(HM, A) < 0): asign = 1
+        mag_angle = asign*math.acos(v_dot(H_hor, M_hor))
 #    print("calc mag A", asign*math.acos(v_dot(H_hor, M_hor)))
 #    print("mag", mx, my, mz)
 #    print("A", ax, ay, az)
-    pitch = round(math.atan2(ay, az)*1000)
+        pitch = round(math.atan2(ay, az)*1000)
 #    print("angles", yaw, pitch, roll)
 #    print("yaw_calc", yaw_q) 
 
-    umyo_list[idx].Qsg[0] = qww
-    umyo_list[idx].Qsg[1] = qwx
-    umyo_list[idx].Qsg[2] = qwy
-    umyo_list[idx].Qsg[3] = qwz
-    umyo_list[idx].yaw = yaw
-    umyo_list[idx].pitch = umyo_list[idx].pitch * 0.95 + 0.05 * pitch
-    if(pitch > 2000 and umyo_list[idx].pitch < -2000): umyo_list[idx].pitch = pitch 
-    if(pitch < -2000 and umyo_list[idx].pitch > 2000): umyo_list[idx].pitch = pitch 
-    umyo_list[idx].roll = roll
-    umyo_list[idx].ax = ax
-    umyo_list[idx].ay = ay
-    umyo_list[idx].az = az
-    umyo_list[idx].mag_angle = mag_angle
+        self.umyo_list[idx].Qsg[0] = qww
+        self.umyo_list[idx].Qsg[1] = qwx
+        self.umyo_list[idx].Qsg[2] = qwy
+        self.umyo_list[idx].Qsg[3] = qwz
+        self.umyo_list[idx].yaw = yaw
+        self.umyo_list[idx].pitch = self.umyo_list[idx].pitch * 0.95 + 0.05 * pitch
+        if(pitch > 2000 and self.umyo_list[idx].pitch < -2000): self.umyo_list[idx].pitch = pitch 
+        if(pitch < -2000 and self.umyo_list[idx].pitch > 2000): self.umyo_list[idx].pitch = pitch 
+        self.umyo_list[idx].roll = roll
+        self.umyo_list[idx].ax = ax
+        self.umyo_list[idx].ay = ay
+        self.umyo_list[idx].az = az
+        self.umyo_list[idx].mag_angle = mag_angle
+
+        # Create and queue the new device data
+        device_data = DeviceData.from_umyo(self.umyo_list[idx])
+        self.data_queue.put(device_data)
 
 #    print(data_id)
 
@@ -198,52 +238,72 @@ def umyo_parse(pos):
 # USB receiver gets those packets and sends them unchanged via USB with adding 3 bytes 
 # before each one: 0x4F, 0xD5 and rssi level measured when receiving this packet.
 
-def umyo_parse_preprocessor(data):
-    parse_buf.extend(data)
-    cnt = len(parse_buf)
+    def umyo_parse_preprocessor(self, data):
+        self.parse_buf.extend(data)
+        cnt = len(self.parse_buf)
 
-    if(cnt < 65): ##  LESS THAN FULL PACKET LENGTH
-        return 0
-    parsed_pos = 0
-    
-    #print(f"""NEW PACKET DETECTED | cnt= {cnt}""")
-    #N = 30  # adjust this number to control items per line
-    #print("\n".join(
-    #    "".join(f"{i}:{b}|" for i, b in enumerate(parse_buf[j:j+N], j+1))
-    #    for j in range(0, len(parse_buf), N)
-    #))  
-    #print('-'*100)
+        if(cnt < 65): ##  LESS THAN FULL PACKET LENGTH
+            return 0
+        parsed_pos = 0
+        packets_processed = 0  # Track number of packets processed
+        
 
-    i=0
-    while i <= (cnt-65):
-        if(parse_buf[i] == 79 and parse_buf[i+1] == 213):
-            packet_len = parse_buf[i+4]
-            if (packet_len == 62):
-                umyo_parse(i+3)
-                parsed_pos = i+3+packet_len
-                i += 1+packet_len
-                continue
-            #else:
-                #print("PARSE ERROR. FOUND HEADER BUT NOT VALID PACKET LENGTH. SKIPPING TO NEXT HEADER")
-                # Note: the while loop will increment i by 1, so we will skip to the next header and the deletion in cumulative
-        i+=1
-    
-    if(parsed_pos > 0): 
-        #print(f'DELETING = {parsed_pos} | BUFFER AFTER DELETION:')
-        del parse_buf[0:parsed_pos]
-
+        #print(f"""NEW PACKET DETECTED | cnt= {cnt}""")
+        #N = 30  # adjust this number to control items per line
         #print("\n".join(
-        # "".join(f"{i}:{b}|" for i, b in enumerate(parse_buf[j:j+N], j+1))
-        #for j in range(0, len(parse_buf), N)
+        #    "".join(f"{i}:{b}|" for i, b in enumerate(parse_buf[j:j+N], j+1))
+        #    for j in range(0, len(parse_buf), N)
         #))  
         #print('-'*100)
-        #print('-'*100)
-    
-    
-    return cnt
 
-def umyo_get_list():
-    return umyo_list
+        i=0
+        while i <= (cnt-65):
+            if(self.parse_buf[i] == 79 and self.parse_buf[i+1] == 213): # Found header (0x4F 0xD5)
+                packet_len = self.parse_buf[i+4]
+                if (packet_len == 62): # valid packet length
+                    self.umyo_parse(i+3)  # Parse this packet
+                    parsed_pos = i+3+packet_len
+                    i += 1+packet_len
+                    packets_processed += 1
+                    continue
+                else:
+                    logger.warning("PARSE ERROR. FOUND HEADER BUT NOT VALID PACKET LENGTH. SKIPPING TO NEXT HEADER")
+                     # Note: the while loop will increment i by 1, so we will skip to the next header and the deletion in cumulative
+            i+=1
+        
+        if(parsed_pos > 0): 
+            #print(f'DELETING = {parsed_pos} | BUFFER AFTER DELETION:')
+            del self.parse_buf[0:parsed_pos]
+        
+            #print("\n".join(
+            # "".join(f"{i}:{b}|" for i, b in enumerate(parse_buf[j:j+N], j+1))
+            #for j in range(0, len(parse_buf), N)
+            #))  
+            #print('-'*100)
+            #print('-'*100)
+
+        return packets_processed  # Return number of packets processed instead of buffer length
+
+    def umyo_get_list(self):
+        return self.umyo_list
 
 
 #packet size = 67 = 62 +5 header
+
+    def parse_packet(self, data):
+        """Main entry point for parsing new data
+        
+        Returns:
+            int: Number of packets processed
+        """
+        return self.umyo_parse_preprocessor(data)
+
+    def get_next_packet(self):
+        """Get the next available packet from the queue
+        
+        Returns:
+            DeviceData or None: The next packet if available, None if queue is empty
+        """
+        if not self.data_queue.empty():
+            return self.data_queue.get()
+        return None


### PR DESCRIPTION
I noticed i was receiving ~275 rows of data per second from a single umyo device. It is supposed to take a sample at 5us acquisition time + 2us conversion time), oversample them 128x, and bundle 8 samples into a data packet. (1 / (0.000007 * 128)) / 8 = 140 packets per second theoretically. So we have been getting ~2x the data. Where does it come from?

The parser code had a subtle bug. Everytime data is received on the serial port the parser is called and the current device data is written to display (or file). The issue is that sometimes the serial port contains a partial packet. The parser is called on this data update. Then regardless of whether we parsed a (full) new packet or not we write a new row of data to screen or file.

The usb basestation adds RSSI and header making the packet size 65, but the station can only send 64 bit packets. so each umyo packet results in 2 basestation packets (64/1). At the python level this results in double the data production with ~half of them duplicates!!!!!!!

I also simplified and optimized the parser logic so it more precisely identifies, validates and processes each packet.

finally i added an illustrative simple_data_logger.py (based on turfptax's script) that logs data using the new parser approach.
